### PR TITLE
Fix: Update Deprecated GitHub Actions in Blog Deployment

### DIFF
--- a/.github/workflows/deploy-blog.yml
+++ b/.github/workflows/deploy-blog.yml
@@ -33,7 +33,7 @@ jobs:
           
       - name: Setup Pages
         id: pages
-        uses: actions/configure-pages@v3
+        uses: actions/configure-pages@v4
         
       - name: Build with Jekyll
         run: |
@@ -43,7 +43,7 @@ jobs:
           JEKYLL_ENV: production
           
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v2
+        uses: actions/upload-pages-artifact@v3
         with:
           path: ./blog/_site
 
@@ -56,4 +56,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v2
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
## Summary

Updates deprecated GitHub Actions versions that were preventing blog deployment to GitHub Pages.

## Issues Fixed

### 🚨 **Deprecated Actions Causing Deployment Failures**
- **Problem**: Blog deployment failing with "deprecated version" errors
- **Root Cause**: GitHub deprecated v3 of artifact actions and older versions of Pages actions
- **Impact**: Blog posts could not be deployed to GitHub Pages (404 errors)

## Actions Updated

| Action | Before | After | Reason |
|--------|--------|-------|---------|
| `actions/configure-pages` | v3 | v4 | Latest stable version |
| `actions/upload-pages-artifact` | v2 | v3 | v2 deprecated by GitHub |
| `actions/deploy-pages` | v2 | v4 | Latest stable version |

## Validation

✅ **Compatibility**: All updated to latest stable versions  
✅ **Workflow Syntax**: No breaking changes in action interfaces  
✅ **Ready for Testing**: Blog deployment should now work properly

This resolves the GitHub Pages deployment failures and prepares the blog system for future use.

🤖 Generated with [Claude Code](https://claude.ai/code)